### PR TITLE
Remove reference from footer

### DIFF
--- a/content/footer.sty
+++ b/content/footer.sty
@@ -1,4 +1,3 @@
 % the back matter
 \clearpage
-\bibliography{references}
 \addcontentsline{toc}{chapter}{References} 


### PR DESCRIPTION
It's already being set by pandoc through the buildscript and causes errors because it appears twice in the output.
